### PR TITLE
FHTEMPLATE-37 - Fix push hello world template (aerogear cordova plugin)

### DIFF
--- a/www/config.json
+++ b/www/config.json
@@ -2,7 +2,8 @@
   "plugins": [
     {
       "id": "org.jboss.aerogear.cordova.push",
-      "version": "1.0.2"
+      "version": "1.0.4",
+      "url": "https://github.com/aerogear/aerogear-cordova-push#1.0.4"
     }
   ]
 }


### PR DESCRIPTION
The push hello world app template uses the aerogear cordova plugin 1.0.2
This plugin is now broken since it depends on a github repo which has updated the cordova id
<dependency id="com.vladstirbu.cordova.promise" url="https://github.com/vstirbu/PromisesPlugin.git"/>

The latest (2.0.2) aerogear-cordova-push plugin uses the updated id.  however that is not available it the old cordova plugin registry. (It is in the npm registry)
