### PR TITLE
RHMAP-15140 - add travis file and move devDependencies to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+group: edge
+sudo: required
+services:
+  - mongodb
+  - docker
+node_js:
+  - "0.10"
+  - "4.4.3"
+before_install:
+  - npm install fh-build -g
+  - fh-build template
+install: npm install

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "push-hello-world-client",
   "private": true,
   "version": "0.0.0",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "grunt-contrib-clean": "~0.5.0",
     "grunt-newer": "~0.5.4",
     "grunt-rev": "~0.1.0",
@@ -13,6 +12,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt": "^0.4.4"
   },
+  "devDependencies": {},
   "engines": {
     "node": ">=0.8.0"
   },


### PR DESCRIPTION
## Motivation
Missing travis build

## Result
Add travis file, move devDependencies to dependencies as fh-build runs npm install with the production flag set and add travis CI service to this repo

## Jira
https://issues.jboss.org/browse/RHMAP-15140